### PR TITLE
fix admin roles problem

### DIFF
--- a/app/controllers/concerns/spree/trackable.rb
+++ b/app/controllers/concerns/spree/trackable.rb
@@ -13,7 +13,7 @@ module Spree
     private
 
     def track_changes?
-      !request.get? && try_spree_current_user.present? && try_spree_current_user.roles.any?(&:admin?)
+      !request.get? && try_spree_current_user.present? && try_spree_current_user.admin?
     end
 
     def store_request_params


### PR DESCRIPTION
Fix the problem of roles.
When `try_spree_current_user.roles.any?(&:admin?)` call, it returns `undefined method roles for #<Spree::User:0x007fd24852eac8>` error.